### PR TITLE
Fee-integration for eNEAR transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,23 @@ This command takes the following command line arguments:
 - --block-height - Min block acceptance height
 - --eth-admin - Eth admin controlled address
 - --paused-flags - Paused flags
+---
+### **Fee-integration in Near-Bridge**
+
+This implements fee for transfers of eNear from `Near -> Ethereum` and `Ethereum -> Near`
+
+* **Fee-Setters**: {Only callable by owner or contract itself}
+  * `set_transfer_fee_percentage`: setter to set the fee-percentage for bi-directional transfers of Near. It has a **6** decimal precision.
+    * *For-example*: if fee-percentage to be set is 10% for both eth-to-near and near-to-eth than values to function parameter is 0.1 * 10^6 ie. 10^5.
+  * `set_deposit_fee_bounds`: setter to set the fee-bounds for deposit ie. transfer from near -> ethereum.
+  * `set_withdraw_fee_bounds`: setter to set the fee-bound for withdraw ie. transfer of eNEAR(Erc-20) from ethereum -> Near.
+  * **NOTE**: 
+    * Default value of fees is 0.
+    * Since 1-NEAR = 10^24 yocto, so fee bounds is to be set in this consideration. For-example to set bounds of {1, 5} NEARs, lower-bound: 10^24 (1-NEAR) and upper-bound: 5 * 10^24 (5-NEARs)
+<br>
+* **Fee-Getters**: {publicly available}
+  * `get_transfer_fee_percentage`: returns transfer-fee-percentage for both eth-to-near and near-to-eth. Default: 0.
+  * `get_deposit_fee_bounds`: returns deposit {near -> eth} fee-bounds. Default returns 0.
+  * `get_withdraw_fee_bounds`: returns withdraw {eth -> near} fee-bounds. Default: 0.
+  * `get_accumulated_fee_amount`: returns claimable fee-amount accumulated.
+  <br>

--- a/nearBridge/src/lib.rs
+++ b/nearBridge/src/lib.rs
@@ -211,6 +211,9 @@ impl NearBridge {
     pub fn get_withdraw_fee_bounds(&self) -> FeeBounds {
         self.withdraw_fee_bounds
     }
+    pub fn get_accumulated_fee_amount(&self) -> u128 {
+        self.cumulative_fee_amount
+    }
 
     fn check_fee_bounds(&self, amount: u128, fee_type: FeeType) -> u128 {
         let fee_bounds = if fee_type == FeeType::Deposit {


### PR DESCRIPTION
This PR covers fee integration for eNear transfers, with changes:

- Fee percentage implementation for `eth_to_near` and `near_to_eth` transfers, with default value as zero.
- Fee percentages have 6 decimal precision.
- Fee bounds can be set individually for both directions.
- Setters are as follows: `set_transfer_fee_percentage`, `set_deposit_fee_bounds`, `set_withdraw_fee_bounds`.
- `only_owner` update to include a owner address which would control fee related setters.
- Amount of fees accumulated are stored in variable `cumulative_fee_amount`.
- Fee accumulated can be claimed by only owner using `claim_fee` method.